### PR TITLE
fix(app): double reactions bug

### DIFF
--- a/app/src/components/posts/PostButtons.tsx
+++ b/app/src/components/posts/PostButtons.tsx
@@ -89,7 +89,7 @@ export default function PostButtons({ messageId, reactions }: PostButtonProps): 
         const numbers: { [key: number]: number } = {};
         reactionsAndButtons.forEach((reactionButton) => {
             numbers[reactionButton.type] =
-                reactions.filter((m) => m.type === reactionButton.type).length +
+                reactions.filter((m) => m.type === reactionButton.type && m.id !== authState?.username).length +
                 (currReaction === reactionButton.type ? 1 : 0);
         });
         return numbers;


### PR DESCRIPTION
In pratica la reazione al post con se stesso veniva contato due volte, una volta dentro il filter, e una volta quando andava a contare sé stesso.